### PR TITLE
Add reusable item tables with soft delete support

### DIFF
--- a/backend/controllers/inventoryController.js
+++ b/backend/controllers/inventoryController.js
@@ -36,3 +36,30 @@ exports.deleteInventory = async (req, res) => {
     res.status(500).json({ error: err.message });
   }
 };
+
+exports.getDeletedInventory = async (req, res) => {
+  try {
+    const rows = await InventoryModel.getDeleted();
+    res.json(rows);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.restoreInventory = async (req, res) => {
+  try {
+    const item = await InventoryModel.restore(req.params.id);
+    res.json(item);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.truncateInventory = async (req, res) => {
+  try {
+    const result = await InventoryModel.truncate();
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/controllers/itemTypeController.js
+++ b/backend/controllers/itemTypeController.js
@@ -46,3 +46,30 @@ exports.deleteItemType = async (req, res) => {
       res.status(500).json({ error: err.message});
   }
 };
+
+exports.getDeletedItemTypes = async (req, res) => {
+  try {
+    const types = await ItemTypeModel.getDeleted();
+    res.json(types);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.restoreItemType = async (req, res) => {
+  try {
+    const type = await ItemTypeModel.restore(req.params.id);
+    res.json(type);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.truncateItemTypes = async (req, res) => {
+  try {
+    const result = await ItemTypeModel.truncate();
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/controllers/itemVariantController.js
+++ b/backend/controllers/itemVariantController.js
@@ -49,3 +49,30 @@ exports.deleteItemVariant = async (req, res) => {
     res.status(500).json({ error: err.message});
   }
 };
+
+exports.getDeletedItemVariants = async (req, res) => {
+  try {
+    const variants = await ItemVariantModel.getDeleted();
+    res.json(variants);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.restoreItemVariant = async (req, res) => {
+  try {
+    const variant = await ItemVariantModel.restore(req.params.id);
+    res.json(variant);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};
+
+exports.truncateItemVariants = async (req, res) => {
+  try {
+    const result = await ItemVariantModel.truncate();
+    res.json(result);
+  } catch (err) {
+    res.status(500).json({ error: err.message });
+  }
+};

--- a/backend/models/inventoryModel.js
+++ b/backend/models/inventoryModel.js
@@ -2,11 +2,23 @@ const db = require('./db');
 
 exports.getAll = async () => {
   const result = await db.query(
-    `SELECT inv.*, iv.name AS variant_name, iv.unit, it.name AS type_name
+    `SELECT inv.*, iv.name AS variant_name, iv.unit, iv.item_type_id, it.name AS type_name
      FROM inventory inv
      JOIN item_variants iv ON inv.item_variant_id = iv.id
      JOIN item_types it ON iv.item_type_id = it.id
      WHERE inv.is_deleted = FALSE
+     ORDER BY inv.id`
+  );
+  return result.rows;
+};
+
+exports.getDeleted = async () => {
+  const result = await db.query(
+    `SELECT inv.*, iv.name AS variant_name, iv.unit, iv.item_type_id, it.name AS type_name
+     FROM inventory inv
+     JOIN item_variants iv ON inv.item_variant_id = iv.id
+     JOIN item_types it ON iv.item_type_id = it.id
+     WHERE inv.is_deleted = TRUE
      ORDER BY inv.id`
   );
   return result.rows;
@@ -37,5 +49,18 @@ exports.update = async (id, { received, sold, qty_on_hand, total_cost_received, 
 
 exports.delete = async (id) => {
   await db.query(`UPDATE inventory SET is_deleted = TRUE WHERE id = $1`, [id]);
+  return { success: true };
+};
+
+exports.restore = async (id) => {
+  const result = await db.query(
+    `UPDATE inventory SET is_deleted = FALSE WHERE id = $1 RETURNING *`,
+    [id]
+  );
+  return result.rows[0];
+};
+
+exports.truncate = async () => {
+  await db.query('TRUNCATE TABLE inventory RESTART IDENTITY CASCADE');
   return { success: true };
 };

--- a/backend/models/itemTypeModel.js
+++ b/backend/models/itemTypeModel.js
@@ -42,3 +42,18 @@ exports.delete = async (id) => {
     await db.query('UPDATE item_types SET is_deleted = TRUE WHERE id = $1', [id]);
     return {success: true};
 };
+
+exports.getDeleted = async () => {
+  const result = await db.query('SELECT * FROM item_types WHERE is_deleted = TRUE ORDER BY id');
+  return result.rows;
+};
+
+exports.restore = async (id) => {
+  const result = await db.query('UPDATE item_types SET is_deleted = FALSE WHERE id = $1 RETURNING *', [id]);
+  return result.rows[0];
+};
+
+exports.truncate = async () => {
+  await db.query('TRUNCATE TABLE item_types RESTART IDENTITY CASCADE');
+  return { success: true };
+};

--- a/backend/models/itemVariantModel.js
+++ b/backend/models/itemVariantModel.js
@@ -1,4 +1,3 @@
-const { isValidElement } = require('react');
 const db = require('./db');
 
 exports.getAll = async () => {
@@ -50,4 +49,28 @@ exports.update = async (id, { name, item_type_id, unit }) => {
 exports.delete = async (id) => {
   await db.query(`UPDATE item_variants SET is_deleted = TRUE WHERE id = $1`, [id]);
   return { success: true};
+};
+
+exports.getDeleted = async () => {
+  const result = await db.query(
+    `SELECT iv.*, it.name AS type_name
+     FROM item_variants iv
+     JOIN item_types it ON iv.item_type_id = it.id
+     WHERE iv.is_deleted = TRUE
+     ORDER BY iv.id`
+  );
+  return result.rows;
+};
+
+exports.restore = async (id) => {
+  const result = await db.query(
+    `UPDATE item_variants SET is_deleted = FALSE WHERE id = $1 RETURNING *`,
+    [id]
+  );
+  return result.rows[0];
+};
+
+exports.truncate = async () => {
+  await db.query('TRUNCATE TABLE item_variants RESTART IDENTITY CASCADE');
+  return { success: true };
 };

--- a/backend/routes/inventoryRoutes.js
+++ b/backend/routes/inventoryRoutes.js
@@ -4,6 +4,10 @@ const inventoryController = require('../controllers/inventoryController');
 
 router.get('/', inventoryController.getAllInventory);
 router.post('/', inventoryController.addInventory);
+// order matters: specific routes before :id
+router.delete('/truncate/all', inventoryController.truncateInventory);
+router.get('/deleted/all', inventoryController.getDeletedInventory);
+router.post('/restore/:id', inventoryController.restoreInventory);
 router.put('/:id', inventoryController.updateInventory);
 router.delete('/:id', inventoryController.deleteInventory);
 

--- a/backend/routes/itemTypeRoutes.js
+++ b/backend/routes/itemTypeRoutes.js
@@ -4,6 +4,10 @@ const itemTypeController = require('../controllers/itemTypeController');
 
 router.get('/', itemTypeController.getAllItemTypes);
 router.post('/', itemTypeController.addItemType);
+// order important: more specific routes first
+router.delete('/truncate/all', itemTypeController.truncateItemTypes);
+router.get('/deleted/all', itemTypeController.getDeletedItemTypes);
+router.post('/restore/:id', itemTypeController.restoreItemType);
 router.put('/:id', itemTypeController.updateItemType);
 router.delete('/:id', itemTypeController.deleteItemType);
 

--- a/backend/routes/itemVariantRoutes.js
+++ b/backend/routes/itemVariantRoutes.js
@@ -4,6 +4,10 @@ const itemVariantController = require('../controllers/itemVariantController');
 
 router.get('/', itemVariantController.getAllItemVariants);
 router.post('/', itemVariantController.addItemVariant);
+// ensure specific routes come before id-based ones
+router.delete('/truncate/all', itemVariantController.truncateItemVariants);
+router.get('/deleted/all', itemVariantController.getDeletedItemVariants);
+router.post('/restore/:id', itemVariantController.restoreItemVariant);
 router.put('/:id', itemVariantController.updateItemVariant);
 router.delete('/:id', itemVariantController.deleteItemVariant);
 

--- a/src/app/inventory/page.tsx
+++ b/src/app/inventory/page.tsx
@@ -1,14 +1,27 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import axios from 'axios';
 import { InventoryItem } from '@/types/inventory';
 import { ItemVariant, ItemType } from '@/types/item';
+import {
+  getInventory,
+  addInventory,
+  deleteInventory,
+  getDeletedInventory,
+  restoreInventory,
+  truncateInventory,
+  getItemVariants,
+  getItemTypes,
+} from '@/lib/api';
+import InventoryTable, { Column } from '@/components/InventoryTable';
 
 export default function InventoryPage() {
   const [inventory, setInventory] = useState<InventoryItem[]>([]);
+  const [deletedInventory, setDeletedInventory] = useState<InventoryItem[]>([]);
   const [variants, setVariants] = useState<ItemVariant[]>([]);
   const [types, setTypes] = useState<ItemType[]>([]);
+  const [showDeleted, setShowDeleted] = useState(false);
+  const [filterType, setFilterType] = useState('');
   const [form, setForm] = useState<any>({
     variant_id: '',
     received: 0,
@@ -19,14 +32,16 @@ export default function InventoryPage() {
   });
 
   const fetchData = async () => {
-    const [invRes, varRes, typeRes] = await Promise.all([
-      axios.get('/api/inventory'),
-      axios.get('/api/variants'),
-      axios.get('/api/types'),
+    const [invRes, deletedInvRes, varRes, typeRes] = await Promise.all([
+      getInventory(),
+      getDeletedInventory(),
+      getItemVariants(),
+      getItemTypes(),
     ]);
-    setInventory(invRes.data);
-    setVariants(varRes.data);
-    setTypes(typeRes.data);
+    setInventory(invRes);
+    setDeletedInventory(deletedInvRes);
+    setVariants(varRes);
+    setTypes(typeRes);
   };
 
   useEffect(() => {
@@ -38,21 +53,38 @@ export default function InventoryPage() {
   };
 
   const handleSubmit = async () => {
-  await axios.post('http://localhost:5000/api/inventory', form);
-  setForm({
-    variant_id: '',
-    received: 0,
-    sold: 0,
-    qty_on_hand: 0,
-    total_cost_received: 0,
-    avg_cost_per_piece: 0
-  });
-  fetchData();
-};
+    await addInventory({
+      item_variant_id: parseInt(form.variant_id),
+      received: Number(form.received),
+      sold: Number(form.sold),
+      qty_on_hand: Number(form.qty_on_hand),
+      total_cost_received: Number(form.total_cost_received),
+      avg_cost_per_piece: Number(form.avg_cost_per_piece),
+    });
+    setForm({
+      variant_id: '',
+      received: 0,
+      sold: 0,
+      qty_on_hand: 0,
+      total_cost_received: 0,
+      avg_cost_per_piece: 0,
+    });
+    fetchData();
+  };
 
 
   const handleDelete = async (id: number) => {
-    await axios.delete(`http://localhost:5000/api/inventory/${id}`);
+    await deleteInventory(id);
+    fetchData();
+  };
+
+  const handleRestore = async (id: number) => {
+    await restoreInventory(id);
+    fetchData();
+  };
+
+  const handleTruncate = async () => {
+    await truncateInventory();
     fetchData();
   };
 
@@ -83,39 +115,52 @@ export default function InventoryPage() {
         <button onClick={handleSubmit} className="bg-blue-600 text-white px-4 py-2">Add/Update</button>
       </div>
 
-      {/* Table */}
-      <table className="table-auto w-full mt-8 border">
-        <thead>
-          <tr className="bg-gray-200">
-            <th>ID</th>
-            <th>Variant</th>
-            <th>Type</th>
-            <th>Received</th>
-            <th>Sold</th>
-            <th>Qty</th>
-            <th>Total Cost</th>
-            <th>Avg Cost</th>
-            <th>Actions</th>
-          </tr>
-        </thead>
-        <tbody>
-          {inventory.map((item) => (
-            <tr key={item.id} className="text-center border-t">
-              <td>{item.id}</td>
-              <td>{item.variant_name}</td>
-              <td>{item.type_name}</td>
-              <td>{item.received}</td>
-              <td>{item.sold}</td>
-              <td>{item.qty_on_hand}</td>
-              <td>{item.total_cost_received}</td>
-              <td>{item.avg_cost_per_piece}</td>
-              <td>
-                <button onClick={() => handleDelete(item.id)} className="text-red-500">Delete</button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <InventoryTable
+        title="Inventory"
+        columns={[
+          { key: 'variant_name', label: 'Variant' },
+          { key: 'type_name', label: 'Type' },
+          { key: 'received', label: 'Received' },
+          { key: 'sold', label: 'Sold' },
+          { key: 'qty_on_hand', label: 'Qty' },
+          { key: 'total_cost_received', label: 'Total Cost' },
+          { key: 'avg_cost_per_piece', label: 'Avg Cost' },
+        ] as Column[]}
+        data={inventory}
+        types={types}
+        filterTypeId={filterType}
+        onFilterChange={setFilterType}
+        onDelete={handleDelete}
+        onTruncate={handleTruncate}
+      />
+
+      <button
+        onClick={() => setShowDeleted(!showDeleted)}
+        className="mb-2 text-sm text-blue-600"
+      >
+        {showDeleted ? 'Hide Deleted Inventory' : 'Show Deleted Inventory'}
+      </button>
+
+      {showDeleted && (
+        <InventoryTable
+          title="Deleted Inventory"
+          columns={[
+            { key: 'variant_name', label: 'Variant' },
+            { key: 'type_name', label: 'Type' },
+            { key: 'received', label: 'Received' },
+            { key: 'sold', label: 'Sold' },
+            { key: 'qty_on_hand', label: 'Qty' },
+            { key: 'total_cost_received', label: 'Total Cost' },
+            { key: 'avg_cost_per_piece', label: 'Avg Cost' },
+          ] as Column[]}
+          data={deletedInventory}
+          types={types}
+          filterTypeId={filterType}
+          onFilterChange={setFilterType}
+          onRestore={handleRestore}
+          isDeletedTable
+        />
+      )}
     </div>
   );
 }

--- a/src/app/items/page.tsx
+++ b/src/app/items/page.tsx
@@ -12,21 +12,37 @@ import {
   updateItemVariant,
   deleteItemType,
   deleteItemVariant,
+  getDeletedItemTypes,
+  getDeletedItemVariants,
+  restoreItemType,
+  restoreItemVariant,
+  truncateItemTypes,
+  truncateItemVariants,
 } from '@/lib/api';
+import ItemTable, { Column } from '@/components/ItemTable';
 
 export default function ItemsPage() {
   const [types, setTypes] = useState<ItemType[]>([]);
   const [variants, setVariants] = useState<ItemVariant[]>([]);
+  const [deletedTypes, setDeletedTypes] = useState<ItemType[]>([]);
+  const [deletedVariants, setDeletedVariants] = useState<ItemVariant[]>([]);
+  const [showDeletedTypes, setShowDeletedTypes] = useState(false);
+  const [showDeletedVariants, setShowDeletedVariants] = useState(false);
+  const [variantFilter, setVariantFilter] = useState('');
   const [typeForm, setTypeForm] = useState<{ name: string; id?: number }>({ name: '' });
   const [variantForm, setVariantForm] = useState<{ name: string; item_type_id: string; unit: string; id?: number }>({ name: '', item_type_id: '', unit: '' });
 
   const fetchData = async () => {
-    const [typesRes, variantsRes] = await Promise.all([
+    const [typesRes, variantsRes, deletedTypesRes, deletedVariantsRes] = await Promise.all([
       getItemTypes(),
       getItemVariants(),
+      getDeletedItemTypes(),
+      getDeletedItemVariants(),
     ]);
     setTypes(typesRes);
     setVariants(variantsRes);
+    setDeletedTypes(deletedTypesRes);
+    setDeletedVariants(deletedVariantsRes);
   };
 
   useEffect(() => {
@@ -61,6 +77,44 @@ export default function ItemsPage() {
     fetchData();
   };
 
+  const removeType = async (id: number) => {
+    await deleteItemType(id);
+    fetchData();
+  };
+
+  const removeVariant = async (id: number) => {
+    await deleteItemVariant(id);
+    fetchData();
+  };
+
+  const restoreTypeHandler = async (id: number) => {
+    await restoreItemType(id);
+    fetchData();
+  };
+
+  const restoreVariantHandler = async (id: number) => {
+    await restoreItemVariant(id);
+    fetchData();
+  };
+
+  const truncateTypesHandler = async () => {
+    await truncateItemTypes();
+    fetchData();
+  };
+
+  const truncateVariantsHandler = async () => {
+    await truncateItemVariants();
+    fetchData();
+  };
+
+  const filteredVariants = variantFilter
+    ? variants.filter((v) => String(v.item_type_id) === variantFilter)
+    : variants;
+
+  const filteredDeletedVariants = variantFilter
+    ? deletedVariants.filter((v) => String(v.item_type_id) === variantFilter)
+    : deletedVariants;
+
   return (
     <div className="p-4 max-w-4xl mx-auto">
       <h1 className="text-2xl font-bold mb-4">Item Types and Variants</h1>
@@ -81,17 +135,29 @@ export default function ItemsPage() {
         </button>
       </div>
 
-      <ul className="mb-8">
-        {types.map((t) => (
-          <li key={t.id} className="flex justify-between items-center mb-1">
-            <span>{t.name}</span>
-            <div className="space-x-2">
-              <button onClick={() => setTypeForm({ name: t.name, id: t.id })} className="text-blue-500">Edit</button>
-              <button onClick={() => { deleteItemType(t.id); fetchData(); }} className="text-red-500">Delete</button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <ItemTable
+        title="Item Types"
+        columns={[{ key: 'name', label: 'Name' }] as Column[]}
+        data={types}
+        onEdit={(item) => setTypeForm({ name: (item as ItemType).name, id: (item as ItemType).id })}
+        onDelete={removeType}
+        onTruncate={truncateTypesHandler}
+      />
+      <button
+        onClick={() => setShowDeletedTypes(!showDeletedTypes)}
+        className="mb-2 text-sm text-blue-600"
+      >
+        {showDeletedTypes ? 'Hide Deleted Types' : 'Show Deleted Types'}
+      </button>
+      {showDeletedTypes && (
+        <ItemTable
+          title="Deleted Item Types"
+          columns={[{ key: 'name', label: 'Name' }] as Column[]}
+          data={deletedTypes}
+          onRestore={restoreTypeHandler}
+          isDeletedTable
+        />
+      )}
 
       {/* Create/Edit Item Variant */}
       <div>
@@ -127,24 +193,55 @@ export default function ItemsPage() {
           {variantForm.id ? 'Update Variant' : 'Add Variant'}
         </button>
       </div>
+      <div className="mb-4">
+        <label className="mr-2 text-sm">Filter by Type:</label>
+        <select
+          value={variantFilter}
+          onChange={(e) => setVariantFilter(e.target.value)}
+          className="border p-1 text-sm"
+        >
+          <option value="">All</option>
+          {types.map((t) => (
+            <option key={t.id} value={t.id}>{t.name}</option>
+          ))}
+        </select>
+      </div>
 
-      <ul className="mt-4">
-        {variants.map((v) => (
-          <li key={v.id} className="flex justify-between items-center mb-1">
-            <span>{v.name} — {v.unit}</span>
-            <div className="space-x-2">
-              <button
-                onClick={() => setVariantForm({ name: v.name, unit: v.unit, item_type_id: String(v.item_type_id), id: v.id })}
-                className="text-blue-500"
-              >Edit</button>
-              <button
-                onClick={() => { deleteItemVariant(v.id); fetchData(); }}
-                className="text-red-500"
-              >Delete</button>
-            </div>
-          </li>
-        ))}
-      </ul>
+      <ItemTable
+        title="Item Variants"
+        columns={[
+          { key: 'name', label: 'Name' },
+          { key: 'type_name', label: 'Type' },
+          { key: 'unit', label: 'Unit' },
+        ] as Column[]}
+        data={filteredVariants}
+        onEdit={(item) =>
+          setVariantForm({ name: (item as ItemVariant).name, unit: (item as ItemVariant).unit, item_type_id: String((item as ItemVariant).item_type_id), id: (item as ItemVariant).id })
+        }
+        onDelete={removeVariant}
+        onTruncate={truncateVariantsHandler}
+      />
+
+      <button
+        onClick={() => setShowDeletedVariants(!showDeletedVariants)}
+        className="mb-2 text-sm text-blue-600"
+      >
+        {showDeletedVariants ? 'Hide Deleted Variants' : 'Show Deleted Variants'}
+      </button>
+
+      {showDeletedVariants && (
+        <ItemTable
+          title="Deleted Item Variants"
+          columns={[
+            { key: 'name', label: 'Name' },
+            { key: 'type_name', label: 'Type' },
+            { key: 'unit', label: 'Unit' },
+          ] as Column[]}
+          data={filteredDeletedVariants}
+          onRestore={restoreVariantHandler}
+          isDeletedTable
+        />
+      )}
     </div>
   );
 }

--- a/src/components/InventoryTable.tsx
+++ b/src/components/InventoryTable.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { InventoryItem } from '@/types/inventory';
+import { ItemType } from '@/types/item';
+
+export type Column = { key: string; label: string };
+
+export interface InventoryTableProps {
+  title?: string;
+  columns: Column[];
+  data: InventoryItem[];
+  types: ItemType[];
+  filterTypeId: string;
+  onFilterChange: (id: string) => void;
+  onEdit?: (item: InventoryItem) => void;
+  onDelete?: (id: number) => void;
+  onRestore?: (id: number) => void;
+  onTruncate?: () => void;
+  isDeletedTable?: boolean;
+}
+
+export default function InventoryTable(props: InventoryTableProps) {
+  const {
+    title,
+    columns,
+    data,
+    types,
+    filterTypeId,
+    onFilterChange,
+    onEdit,
+    onDelete,
+    onRestore,
+    onTruncate,
+    isDeletedTable,
+  } = props;
+
+  const filtered = filterTypeId
+    ? data.filter((d) => String(d.item_type_id) === filterTypeId)
+    : data;
+
+  return (
+    <div className="mb-8">
+      {title && <h2 className="text-xl font-semibold mb-2">{title}</h2>}
+      <div className="flex items-center gap-2 mb-2">
+        <select
+          value={filterTypeId}
+          onChange={(e) => onFilterChange(e.target.value)}
+          className="border p-1 text-sm"
+        >
+          <option value="">All Types</option>
+          {types.map((t) => (
+            <option key={t.id} value={t.id}>
+              {t.name}
+            </option>
+          ))}
+        </select>
+        {onTruncate && (
+          <button
+            onClick={onTruncate}
+            className="bg-red-600 text-white px-2 py-1 text-sm rounded"
+          >
+            Truncate
+          </button>
+        )}
+      </div>
+      <table className="min-w-full border border-gray-300 rounded shadow-sm text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            {columns.map((col) => (
+              <th key={col.key} className="border px-2 py-1 text-left">
+                {col.label}
+              </th>
+            ))}
+            {(onEdit || onDelete || onRestore) && (
+              <th className="border px-2 py-1">Actions</th>
+            )}
+          </tr>
+        </thead>
+        <tbody>
+          {filtered.map((item) => (
+            <tr key={item.id} className="border-t">
+              {columns.map((col) => (
+                <td key={col.key} className="border px-2 py-1">
+                  {(item as any)[col.key]}
+                </td>
+              ))}
+              {(onEdit || onDelete || onRestore) && (
+                <td className="border px-2 py-1 space-x-2">
+                  {onEdit && (
+                    <button
+                      onClick={() => onEdit(item)}
+                      className="text-blue-500"
+                    >
+                      Edit
+                    </button>
+                  )}
+                  {onDelete && !isDeletedTable && (
+                    <button
+                      onClick={() => onDelete(item.id)}
+                      className="text-red-500"
+                    >
+                      Delete
+                    </button>
+                  )}
+                  {onRestore && isDeletedTable && (
+                    <button
+                      onClick={() => onRestore(item.id)}
+                      className="text-green-600"
+                    >
+                      Restore
+                    </button>
+                  )}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/components/ItemTable.tsx
+++ b/src/components/ItemTable.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+export type Column = {
+  key: string;
+  label: string;
+};
+
+export interface ItemTableProps<T> {
+  title?: string;
+  columns: Column[];
+  data: T[];
+  onEdit?: (item: T) => void;
+  onDelete?: (id: number) => void;
+  onRestore?: (id: number) => void;
+  onTruncate?: () => void;
+  isDeletedTable?: boolean;
+}
+
+export default function ItemTable<T extends { id: number }>(props: ItemTableProps<T>) {
+  const { title, columns, data, onEdit, onDelete, onRestore, onTruncate, isDeletedTable } = props;
+  return (
+    <div className="mb-8">
+      {title && <h2 className="text-xl font-semibold mb-2">{title}</h2>}
+      {onTruncate && (
+        <button onClick={onTruncate} className="mb-2 bg-red-600 text-white px-2 py-1 text-sm rounded">
+          Truncate
+        </button>
+      )}
+      <table className="min-w-full border border-gray-300 rounded shadow-sm text-sm">
+        <thead className="bg-gray-100">
+          <tr>
+            {columns.map(col => (
+              <th key={col.key} className="border px-2 py-1 text-left">{col.label}</th>
+            ))}
+            {(onEdit || onDelete || onRestore) && <th className="border px-2 py-1">Actions</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map(item => (
+            <tr key={(item as any).id} className="border-t">
+              {columns.map(col => (
+                <td key={col.key} className="border px-2 py-1">{(item as any)[col.key]}</td>
+              ))}
+              {(onEdit || onDelete || onRestore) && (
+                <td className="border px-2 py-1 space-x-2">
+                  {onEdit && <button onClick={() => onEdit(item)} className="text-blue-500">Edit</button>}
+                  {onDelete && !isDeletedTable && (
+                    <button onClick={() => onDelete((item as any).id)} className="text-red-500">Delete</button>
+                  )}
+                  {onRestore && isDeletedTable && (
+                    <button onClick={() => onRestore((item as any).id)} className="text-green-600">Restore</button>
+                  )}
+                </td>
+              )}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,4 +1,4 @@
-const BASE_URL = 'http://localhost:5000';
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:5000';
 
 // INVENTORY
 export async function getInventory() {
@@ -26,6 +26,25 @@ export async function updateInventory(id: number, item: any) {
 
 export async function deleteInventory(id: number) {
   const res = await fetch(`${BASE_URL}/api/inventory/${id}`, {
+    method: 'DELETE',
+  });
+  return res.json();
+}
+
+export async function getDeletedInventory() {
+  const res = await fetch(`${BASE_URL}/api/inventory/deleted/all`);
+  return res.json();
+}
+
+export async function restoreInventory(id: number) {
+  const res = await fetch(`${BASE_URL}/api/inventory/restore/${id}`, {
+    method: 'POST',
+  });
+  return res.json();
+}
+
+export async function truncateInventory() {
+  const res = await fetch(`${BASE_URL}/api/inventory/truncate/all`, {
     method: 'DELETE',
   });
   return res.json();
@@ -60,6 +79,21 @@ export async function deleteItemType(id: number) {
   return res.json();
 }
 
+export async function getDeletedItemTypes() {
+  const res = await fetch(`${BASE_URL}/api/item-types/deleted/all`);
+  return res.json();
+}
+
+export async function restoreItemType(id: number) {
+  const res = await fetch(`${BASE_URL}/api/item-types/restore/${id}`, { method: 'POST' });
+  return res.json();
+}
+
+export async function truncateItemTypes() {
+  const res = await fetch(`${BASE_URL}/api/item-types/truncate/all`, { method: 'DELETE' });
+  return res.json();
+}
+
 // ITEM VARIANTS
 export async function getItemVariants() {
   const res = await fetch(`${BASE_URL}/api/item-variants`);
@@ -86,5 +120,20 @@ export async function updateItemVariant(id: number, variant: any) {
 
 export async function deleteItemVariant(id: number) {
   const res = await fetch(`${BASE_URL}/api/item-variants/${id}`, { method: 'DELETE' });
+  return res.json();
+}
+
+export async function getDeletedItemVariants() {
+  const res = await fetch(`${BASE_URL}/api/item-variants/deleted/all`);
+  return res.json();
+}
+
+export async function restoreItemVariant(id: number) {
+  const res = await fetch(`${BASE_URL}/api/item-variants/restore/${id}`, { method: 'POST' });
+  return res.json();
+}
+
+export async function truncateItemVariants() {
+  const res = await fetch(`${BASE_URL}/api/item-variants/truncate/all`, { method: 'DELETE' });
   return res.json();
 }

--- a/src/types/inventory.ts
+++ b/src/types/inventory.ts
@@ -1,6 +1,7 @@
 export type InventoryItem = {
   id: number;
   item_variant_id: number;
+  item_type_id: number;
   received: number;
   sold: number;
   qty_on_hand: number;

--- a/src/types/item.ts
+++ b/src/types/item.ts
@@ -8,4 +8,5 @@ export type ItemVariant = {
   name: string;
   item_type_id: number;
   unit: string;
+  type_name?: string;
 };


### PR DESCRIPTION
## Summary
- create a generic `ItemTable` component
- extend item type and variant models/controllers/routes with fetch deleted, restore, and truncate capabilities
- expose new API helpers for those endpoints
- update `ItemVariant` type with `type_name`
- refactor `ItemsPage` to use `ItemTable` and handle deleted/restored items

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840be71d264832cb96e11c161f5eacd